### PR TITLE
add syntax highlight

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-church-slavonic",
     "displayName": "vscode-church-slavonic",
-    "icon": "images/logo.png",
+    "icon": "./images/logo.png",
     "description": "Church Slavonic Markdown",
     "version": "0.1.2",
     "repository": {
@@ -35,6 +35,15 @@
             {
                 "command": "church-slavonic-generate-latex",
                 "title": "CU Generate LaTeX"
+            }
+        ],
+        "grammars": [
+            {
+                "path": "./syntaxes/markdown-churchslavonic.json",
+                "scopeName": "markdown.churchslavonic",
+                "injectTo": [
+                    "text.html.markdown"
+                ]
             }
         ]
     },

--- a/syntaxes/markdown-churchslavonic.json
+++ b/syntaxes/markdown-churchslavonic.json
@@ -1,0 +1,104 @@
+{
+    "scopeName": "markdown.churchslavonic",
+    "injectionSelector": "L:meta.paragraph.markdown",
+    "patterns": [
+        {
+            "include": "#kinovar"
+        },
+        {
+            "include": "#wide"
+        },
+        {
+            "include": "#redbukva"
+        },
+        {
+            "include": "#bukvitsa"
+        },
+        {
+            "include": "#pagebreak1"
+        },
+        {
+            "include": "#pagebreak2"
+        }
+    ],
+    "repository": {
+        "kinovar": {
+            "name": "markup.kinovar",
+            "match": "(=)([^=]+)(=)",
+            "captures": {
+                "1": {
+                    "name": "markup.kinovar.delim"
+                },
+                "3": {
+                    "name": "markup.kinovar.delim"
+                }
+            }
+        },
+        "wide": {
+            "name": "markup.wide",
+            "match": "(\\+)([^\\+]+)(\\+)",
+            "captures": {
+                "1": {
+                    "name": "markup.wide.delim"
+                },
+                "3": {
+                    "name": "markup.wide.delim"
+                }
+            }
+        },
+        "redbukva": {
+            "name": "markup.kinovar.redbukva",
+            "match": "(\\~)((?:оу|Оу|ᲂу|\\p{L})\\p{M}*)",
+            "captures": {
+                "1": {
+                    "name": "markup.kinovar.delim"
+                }
+            }
+        },
+        "bukvitsa": {
+            "name": "markup.bukvitsa",
+            "match": "(\\^)((?:оу|Оу|ᲂу|\\p{L})\\p{M}*)",
+            "captures": {
+                "1": {
+                    "name": "markup.bukvitsa.delim"
+                }
+            }
+        },
+        "pagebreak1": {
+            "name": "markup.pagebreak",
+            "match": "(\\<\\<)\\s*(\\d+)\\s*(\\>\\>)",
+            "captures": {
+                "1": {
+                    "name": "markup.pagebreak.delim"
+                },
+                "2": {
+                    "name": "markup.pagebreak.number"
+                },
+                "3": {
+                    "name": "markup.pagebreak.delim"
+                }
+            }
+        },
+        "pagebreak2": {
+            "name": "markup.pagebreak",
+            "match": "(\\<\\<)\\s*(\\d+)\\s*(:)\\s*(.*?)(\\>\\>)",
+            "captures": {
+                "1": {
+                    "name": "markup.pagebreak.delim"
+                },
+                "2": {
+                    "name": "markup.pagebreak.number"
+                },
+                "3": {
+                    "name": "markup.pagebreak.delim"
+                },
+                "4": {
+                    "name": "markup.pagebreak.label"
+                },
+                "5": {
+                    "name": "markup.pagebreak.delim"
+                }
+            }
+        }
+    }
+}

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,52 @@
+const COLOR = {
+    KINOVAR: '#cc0803',
+    KINOVAR_MUTED: '#cc080370',
+    WIDE: '#379260',
+    WIDE_MUTED: '#37926070',
+    BUKVITSA: '#3760a2',
+    BUKVITSA_MUTED: '#3760a270',
+    PAGEBREAK_NUMBER: '#00ffa2',
+    PAGEBREAK_LABEL: '#ffffa2',
+    PAGEBREAK_DELIM: '#00ffa270',
+};
+
+const theme = [
+    {
+        scope: 'markup.kinovar',
+        settings: { foreground: COLOR.KINOVAR }
+    },
+    {
+        scope: 'markup.kinovar.delim',
+        settings: { foreground: COLOR.KINOVAR_MUTED }
+    },
+    {
+        scope: 'markup.wide',
+        settings: { foreground: COLOR.WIDE }
+    },
+    {
+        scope: 'markup.wide.delim',
+        settings: { foreground: COLOR.WIDE_MUTED }
+    },
+    {
+        scope: 'markup.bukvitsa',
+        settings: { foreground: COLOR.BUKVITSA }
+    },
+    {
+        scope: 'markup.bukvitsa.delim',
+        settings: { foreground: COLOR.BUKVITSA_MUTED }
+    },
+    {
+        scope: 'markup.pagebreak.number',
+        settings: { foreground: COLOR.PAGEBREAK_NUMBER }
+    },
+    {
+        scope: 'markup.pagebreak.label',
+        settings: { foreground: COLOR.PAGEBREAK_LABEL }
+    },
+    {
+        scope: 'markup.pagebreak.delim',
+        settings: { foreground: COLOR.PAGEBREAK_DELIM }
+    },
+];
+
+exports.theme = theme ;


### PR DESCRIPTION
add grammar and themes to highlight church slavonic markdown syntax.

![image](https://user-images.githubusercontent.com/569458/60056790-258e3d00-96b0-11e9-9745-aac820d46e99.png)
